### PR TITLE
Fix "offset less than minimum bound" error

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -78,7 +78,7 @@ function grain(p,buffer,positionx,positiony,attack,release,spread,pan){
 
 	this.randomoffset = (Math.random() * this.spread) - (this.spread / 2); //in seconds
 	///envelope
-	this.source.start(this.now,this.offset + this.randomoffset,this.attack + this.release); //parameters (when,offset,duration)
+	this.source.start(this.now,Math.max(0, this.offset + this.randomoffset),this.attack + this.release); //parameters (when,offset,duration)
 	this.gain.gain.setValueAtTime(0.0, this.now);
 	this.gain.gain.linearRampToValueAtTime(this.amp,this.now + this.attack);
 	this.gain.gain.linearRampToValueAtTime(0,this.now + (this.attack +  this.release) );


### PR DESCRIPTION
Set an offset floor of zero to prevent error when a grain is created with a negative offset.

![chrome-capture](https://user-images.githubusercontent.com/27911455/129484471-fb1b90cc-6381-41ad-b6e2-815dfc73d759.gif)
